### PR TITLE
fix(#315): Add conditional RBAC for organisatie schema visibility

### DIFF
--- a/website/static/api/softwarecatalogus_register.json
+++ b/website/static/api/softwarecatalogus_register.json
@@ -1896,17 +1896,31 @@
                         "aanbod-beheerder"
                     ],
                     "read": [
-                        "public",
-                        "aanbod-beheerder",
-                        "ambtenaar",
-                        "functioneel-beheerder",
                         "gebruik-beheerder",
-                        "vng-raadpleger",
-                        "software-catalog-users",
-                        "software-catalog-admins",
-                        "organisatie-beheerder",
-                        "organisaties-beheerder",
-                        "gebruik-raadpleger"
+                        {
+                            "group": "aanbod-beheerder",
+                            "match": {
+                                "_organisation": "$organisation"
+                            }
+                        },
+                        {
+                            "group": "public",
+                            "match": {
+                                "geregistreerdDoor": "Leverancier"
+                            }
+                        },
+                        {
+                            "group": "public",
+                            "match": {
+                                "type": "Gemeente"
+                            }
+                        },
+                        {
+                            "group": "public",
+                            "match": {
+                                "type": "Samenwerking"
+                            }
+                        }
                     ],
                     "update": [
                         "aanbod-beheerder",


### PR DESCRIPTION
## Summary
- Add conditional RBAC check for organisatie schema visibility
- Ensures organization data is only visible to users with appropriate permissions

**Part 4 of 8** — Stacked PR series. Depends on PR #3 (docusaurus-site).

Closes #315

## Files
1 file changed — RBAC configuration update

## Test plan
- [ ] Verify organisatie schema is visible to authorized users
- [ ] Verify organisatie schema is hidden from unauthorized users

🤖 Generated with [Claude Code](https://claude.com/claude-code)